### PR TITLE
Update ssl defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,8 +43,8 @@ apache_options:
   - "-Indexes"
   - "+FollowSymLinks"
 
-apache_ssl_protocol: "All -SSLv2 -SSLv3"
-apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
+apache_ssl_protocol: "All -SSLv2 -SSLv3 -TLSv1 -TLSv1.1"
+apache_ssl_cipher_suite: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
 
 # @var apache_mods_enabled:description: >
 # Only used on Debian/Ubuntu. CentOS/RHEL will auto enable available modules.


### PR DESCRIPTION
Adjusted the SSL cipher suite and protocol defaults according to the mozilla SSL configuration generator's intermediate configuration.
This changes the rating of the setup in ssllabs.com from "B" to "A+".