### PR TITLE
refactor: drop support for SSLCertificateChainFile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ apache_vhosts_ssl: []
 #
 #     # Location of the SSL certificate file to use. The file has to exist on the target host already or
 #     # you can use `certificate_file_source` to deploy a certificate located on the Ansible control host.
+#     # This file contains the SSL certificate and may also include intermediate CA certificates, sorted from
+#     # leaf to root to create a full chain certificate.
 #     certificate_file: "/path/to/certificate.crt"
 #
 #     # Location of the SSL certificate key file to use. The file has to exist on the target host already or
@@ -54,8 +56,6 @@ apache_vhosts_ssl: []
 #     # variables are not set, the SSL certificates need to be located on the tarhet host already.
 #     certificate_file_source: "/path/to/source/on/ansible_host/certificate.crt"
 #     certificate_key_source: "/path/to/source/on/ansible_host/certificate.key"
-#     certificate_chain_file: "/path/to/certificate_chain.crt"
-#     certificate_chain_source: "/path/to/source/on/ansible_host/certificate_chain.crt"
 #
 #     header_hsts_options:
 #       - max-age=63072000

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -5,7 +5,6 @@
       {{
         __apache_cert_files | default([]) + [
           { 'src': item.certificate_file_source | default(False), 'dest': item.certificate_file | default(False), 'mode': '0750' },
-          { 'src': item.certificate_chain_source | default(False), 'dest': item.certificate_chain_file | default(False), 'mode': '0750' },
           { 'src': item.certificate_key_source | default(False), 'dest': item.certificate_key_file | default(False), 'mode': '0600' },
         ]
       }}

--- a/templates/owncloud.conf.j2
+++ b/templates/owncloud.conf.j2
@@ -48,9 +48,6 @@
   SSLCompression off
   SSLCertificateFile {{ vhost.certificate_file }}
   SSLCertificateKeyFile {{ vhost.certificate_key_file }}
-{% if vhost.certificate_chain_file is defined %}
-  SSLCertificateChainFile {{ vhost.certificate_chain_file }}
-{% endif %}
 
 {% if vhost.header_hsts_options is defined %}
   # protect against protocol downgrading and cookie hijacking


### PR DESCRIPTION
See https://github.com/owncloud-ansible/apache/pull/25#discussion_r808946626 and https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcertificatefile. As we deploy the required apache min version on all operating systems, let's drop it. 

BREAKING CHANGE: The usage of the `SSLCertificateChainFile` configuration is obsolete. Therefor, the variables `certificate_chain_file` and `certificate_chain_source` were removed from the role. As an alternative, the certificate file specified with `certificate_file`  may also include intermediate CA certificates, sorted from leaf to root, to create a full chain certificate.