### PR TITLE
Typo fix for apache_vhosts_ssl

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ apache_vhost_name: "owncloud.conf"
 
 apache_vhosts_ssl: []
 # @var apache_vhosts_ssl:description: >
-# Define SSL enbaled Vhost configurations. The example below shows all available properties that can be set.
+# Define SSL enabled Vhost configurations. The example below shows all available properties that can be set.
 # @end
 
 # @var apache_vhosts_ssl:example: >


### PR DESCRIPTION
The variable description contains a typo which is then visible in the documentation at https://owncloud-ansible.github.io/role/apache/#apache_ssl_cipher_suite